### PR TITLE
feat: Proper wound RNG modes

### DIFF
--- a/bin/common/Language/Technical/en-US.yml
+++ b/bin/common/Language/Technical/en-US.yml
@@ -56,9 +56,9 @@ en-US:
   DRT_STANDARD: "standard damage range"
   DRT_EXPLOSION: "explosion damage range"
 #
-  WM_LINEAR: "flat"
-  WM_VANILLA: "vanilla"
-  WM_RANDOM: "0-100% spread"
+  WRT_LINEAR: "flat"
+  WRT_VANILLA: "vanilla"
+  WRT_RANDOM: "0-100% spread"
 #
   BFT_NONE: "none"
   BFT_INSTANT: "instant"

--- a/bin/common/Language/Technical/en-US.yml
+++ b/bin/common/Language/Technical/en-US.yml
@@ -56,6 +56,10 @@ en-US:
   DRT_STANDARD: "standard damage range"
   DRT_EXPLOSION: "explosion damage range"
 #
+  WRT_LINEAR: "flat"
+  WRT_VANILLA: "vanilla"
+  WRT_RANDOM: "0-100% spread"
+#
   BFT_NONE: "none"
   BFT_INSTANT: "instant"
   BFT_SET: "manually set"

--- a/bin/common/Language/Technical/en-US.yml
+++ b/bin/common/Language/Technical/en-US.yml
@@ -56,9 +56,9 @@ en-US:
   DRT_STANDARD: "standard damage range"
   DRT_EXPLOSION: "explosion damage range"
 #
-  WRT_LINEAR: "flat"
-  WRT_VANILLA: "vanilla"
-  WRT_RANDOM: "0-100% spread"
+  WM_LINEAR: "flat"
+  WM_VANILLA: "vanilla"
+  WM_RANDOM: "0-100% spread"
 #
   BFT_NONE: "none"
   BFT_INSTANT: "instant"

--- a/bin/common/Language/Technical/en-US.yml
+++ b/bin/common/Language/Technical/en-US.yml
@@ -204,7 +204,7 @@ en-US:
   ToStun: "Stun damage multiplier"
   RandomStun: "Stun damage RNG?"
   ToWound: "Wound count multiplier"
-  RandomWound: "Vanilla wound RNG?"
+  RandomWound: "Wound RNG mode"
   ToTime: "TU damage multiplier"
   RandomTime: "TU damage RNG?"
   ToEnergy: "Energy dmg multiplier"

--- a/src/Mod/RuleDamageType.cpp
+++ b/src/Mod/RuleDamageType.cpp
@@ -33,7 +33,7 @@ RuleDamageType::RuleDamageType() :
 	ArmorEffectiveness(1.0f), RadiusEffectiveness(0.0f), RadiusReduction(10.0f),
 	FireThreshold(1000), SmokeThreshold(1000),
 	ToHealth(1.0f), ToMana(0.0f), ToArmor(0.1f), ToArmorPre(0.0f), ToWound(1.0f), ToItem(0.0f), ToTile(0.5f), ToStun(0.25f), ToEnergy(0.0f), ToTime(0.0f), ToMorale(0.0f),
-	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(1), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
+	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(WoundMode::VANILLA), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
 	TileDamageMethod(1)
 {
 
@@ -275,17 +275,19 @@ int RuleDamageType::getWoundFinalDamage(int damage) const
 {
 	if (damage > 0)
 	{
+		int woundPotential = static_cast<int>(std::round(damage * ToWound));
 		switch (RandomWound)
 		{
-			case 1:
-				if (RNG::generate(0, 10) < int(damage * ToWound))
+			case WoundMode::LINEAR:
+				if (RNG::generate(0, 10) < woundPotential)
 				{
 					return RNG::generate(1, 3);
 				}
-			case 0:
-				return (int)std::round(damage * ToWound);
-			case 2:
-				return RNG::generate(0, (int)std::round(damage * ToWound));
+				break;
+			case WoundMode::VANILLA:
+				return woundPotential;
+			case WoundMode::RANDOM:
+				return RNG::generate(0, woundPotential);
 		}
 	}
 	return 0;

--- a/src/Mod/RuleDamageType.cpp
+++ b/src/Mod/RuleDamageType.cpp
@@ -33,7 +33,7 @@ RuleDamageType::RuleDamageType() :
 	ArmorEffectiveness(1.0f), RadiusEffectiveness(0.0f), RadiusReduction(10.0f),
 	FireThreshold(1000), SmokeThreshold(1000),
 	ToHealth(1.0f), ToMana(0.0f), ToArmor(0.1f), ToArmorPre(0.0f), ToWound(1.0f), ToItem(0.0f), ToTile(0.5f), ToStun(0.25f), ToEnergy(0.0f), ToTime(0.0f), ToMorale(0.0f),
-	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(true), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
+	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(1), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
 	TileDamageMethod(1)
 {
 
@@ -275,16 +275,17 @@ int RuleDamageType::getWoundFinalDamage(int damage) const
 {
 	if (damage > 0)
 	{
-		if (RandomWound)
+		switch (RandomWound)
 		{
-			if (RNG::generate(0, 10) < int(damage * ToWound))
-			{
-				return RNG::generate(1,3);
-			}
-		}
-		else
-		{
-			return (int)std::round(damage * ToWound);
+			case 1:
+				if (RNG::generate(0, 10) < int(damage * ToWound))
+				{
+					return RNG::generate(1, 3);
+				}
+			case 0:
+				return (int)std::round(damage * ToWound);
+			case 2:
+				return RNG::generate(0, (int)std::round(damage * ToWound));
 		}
 	}
 	return 0;

--- a/src/Mod/RuleDamageType.cpp
+++ b/src/Mod/RuleDamageType.cpp
@@ -33,7 +33,7 @@ RuleDamageType::RuleDamageType() :
 	ArmorEffectiveness(1.0f), RadiusEffectiveness(0.0f), RadiusReduction(10.0f),
 	FireThreshold(1000), SmokeThreshold(1000),
 	ToHealth(1.0f), ToMana(0.0f), ToArmor(0.1f), ToArmorPre(0.0f), ToWound(1.0f), ToItem(0.0f), ToTile(0.5f), ToStun(0.25f), ToEnergy(0.0f), ToTime(0.0f), ToMorale(0.0f),
-	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(WoundMode::VANILLA), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
+	RandomHealth(false), RandomMana(false), RandomArmor(false), RandomArmorPre(false), RandomWound(ItemWoundRandomType::VANILLA), RandomItem(false), RandomTile(false), RandomStun(true), RandomEnergy(false), RandomTime(false), RandomMorale(false),
 	TileDamageMethod(1)
 {
 
@@ -278,15 +278,15 @@ int RuleDamageType::getWoundFinalDamage(int damage) const
 		int woundPotential = static_cast<int>(std::round(damage * ToWound));
 		switch (RandomWound)
 		{
-			case WoundMode::LINEAR:
+			case ItemWoundRandomType::LINEAR:
 				if (RNG::generate(0, 10) < woundPotential)
 				{
 					return RNG::generate(1, 3);
 				}
 				break;
-			case WoundMode::VANILLA:
+			case ItemWoundRandomType::VANILLA:
 				return woundPotential;
-			case WoundMode::RANDOM:
+			case ItemWoundRandomType::RANDOM:
 				return RNG::generate(0, woundPotential);
 		}
 	}

--- a/src/Mod/RuleDamageType.h
+++ b/src/Mod/RuleDamageType.h
@@ -38,6 +38,12 @@ enum ItemDamageRandomType
 	DRT_EXPLOSION = 9,
 	DRT_UFO_WITH_FOUR_DICE = 10
 };
+enum class WoundMode : int
+{
+	VANILLA = 0,
+	LINEAR = 1,
+	RANDOM = 2
+};
 
 /**
  * Represents a specific damage type.
@@ -106,8 +112,8 @@ struct RuleDamageType
 	bool RandomArmor;
 	/// Damage type use random conversion armor pre damage.
 	bool RandomArmorPre;
-	/// Damage type use random chance for wound number or linear.
-	int RandomWound;
+	/// Damage type use vanilla wound formula, linear or random conversion.
+	WoundMode RandomWound;
 	/// Damage type use random conversion item damage.
 	bool RandomItem;
 	/// Damage type use random conversion tile damage.

--- a/src/Mod/RuleDamageType.h
+++ b/src/Mod/RuleDamageType.h
@@ -107,7 +107,7 @@ struct RuleDamageType
 	/// Damage type use random conversion armor pre damage.
 	bool RandomArmorPre;
 	/// Damage type use random chance for wound number or linear.
-	bool RandomWound;
+	int RandomWound;
 	/// Damage type use random conversion item damage.
 	bool RandomItem;
 	/// Damage type use random conversion tile damage.

--- a/src/Mod/RuleDamageType.h
+++ b/src/Mod/RuleDamageType.h
@@ -38,7 +38,7 @@ enum ItemDamageRandomType
 	DRT_EXPLOSION = 9,
 	DRT_UFO_WITH_FOUR_DICE = 10
 };
-enum class WoundMode : int
+enum class ItemWoundRandomType : int
 {
 	VANILLA = 0,
 	LINEAR = 1,
@@ -113,7 +113,7 @@ struct RuleDamageType
 	/// Damage type use random conversion armor pre damage.
 	bool RandomArmorPre;
 	/// Damage type use vanilla wound formula, linear or random conversion.
-	WoundMode RandomWound;
+	ItemWoundRandomType RandomWound;
 	/// Damage type use random conversion item damage.
 	bool RandomItem;
 	/// Damage type use random conversion tile damage.

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -1812,7 +1812,7 @@ void StatsForNerdsState::addSoundVectorResourcePaths(std::ostringstream &ss, Mod
 /**
  * Adds a WoundMode to the table.
  */
-void StatsForNerdsState::addWoundMode(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue)
+void StatsForNerdsState::addRandomWound(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue)
 {
 	if (value == defaultvalue && !_showDefaults)
 	{
@@ -2091,7 +2091,7 @@ void StatsForNerdsState::initItemList()
 		addBoolean(ss, rule->RandomStun, "RandomStun", ruleByResistType->RandomStun);
 
 		addFloatAsPercentage(ss, rule->ToWound, "ToWound", ruleByResistType->ToWound);
-		addWoundMode(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
+		addRandomWound(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
 
 		addFloatAsPercentage(ss, rule->ToTime, "ToTime", ruleByResistType->ToTime);
 		addBoolean(ss, rule->RandomTime, "RandomTime", ruleByResistType->RandomTime);

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -1810,9 +1810,9 @@ void StatsForNerdsState::addSoundVectorResourcePaths(std::ostringstream &ss, Mod
 }
 
 /**
- * Adds a WoundMode to the table.
+ * Adds a wound random type to the table.
  */
-void StatsForNerdsState::addRandomWound(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue)
+void StatsForNerdsState::addRandomWound(std::ostringstream& ss, const ItemWoundRandomType& value, const std::string& propertyName, const ItemWoundRandomType& defaultvalue)
 {
 	if (value == defaultvalue && !_showDefaults)
 	{
@@ -1823,14 +1823,14 @@ void StatsForNerdsState::addRandomWound(std::ostringstream& ss, const WoundMode&
 
 	switch (value)
 	{
-	case WoundMode::LINEAR:
-		ss << tr("WM_LINEAR");
+	case ItemWoundRandomType::LINEAR:
+		ss << tr("WRT_LINEAR");
 		break;
-	case WoundMode::VANILLA:
-		ss << tr("WM_VANILLA");
+	case ItemWoundRandomType::VANILLA:
+		ss << tr("WRT_VANILLA");
 		break;
-	case WoundMode::RANDOM:
-		ss << tr("WM_RANDOM");
+	case ItemWoundRandomType::RANDOM:
+		ss << tr("WRT_RANDOM");
 		break;
 	default:
 		ss << tr("STR_UNKNOWN");

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -1810,6 +1810,48 @@ void StatsForNerdsState::addSoundVectorResourcePaths(std::ostringstream &ss, Mod
 }
 
 /**
+ * Adds a WoundMode to the table.
+ */
+void StatsForNerdsState::addWoundMode(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue)
+{
+	if (value == defaultvalue && !_showDefaults)
+	{
+		return;
+	}
+
+	resetStream(ss);
+
+	switch (value)
+	{
+	case WoundMode::LINEAR:
+		ss << tr("WRT_LINEAR");
+		break;
+	case WoundMode::VANILLA:
+		ss << tr("WRT_VANILLA");
+		break;
+	case WoundMode::RANDOM:
+		ss << tr("WRT_RANDOM");
+		break;
+	default:
+		ss << tr("STR_UNKNOWN");
+		break;
+	}
+
+	if (_showIds)
+	{
+		ss << " [" << (int)value << "]";
+	}
+
+	_lstRawData->addRow(2, trp(propertyName).c_str(), ss.str().c_str());
+	++_counter;
+
+	if (value != defaultvalue)
+	{
+		_lstRawData->setCellColor(_lstRawData->getLastRowIndex(), 1, _pink);
+	}
+}
+
+/**
  * Shows the "raw" RuleItem data.
  */
 void StatsForNerdsState::initItemList()
@@ -2049,7 +2091,7 @@ void StatsForNerdsState::initItemList()
 		addBoolean(ss, rule->RandomStun, "RandomStun", ruleByResistType->RandomStun);
 
 		addFloatAsPercentage(ss, rule->ToWound, "ToWound", ruleByResistType->ToWound);
-		addInteger(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
+		addWoundMode(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
 
 		addFloatAsPercentage(ss, rule->ToTime, "ToTime", ruleByResistType->ToTime);
 		addBoolean(ss, rule->RandomTime, "RandomTime", ruleByResistType->RandomTime);

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -1824,13 +1824,13 @@ void StatsForNerdsState::addRandomWound(std::ostringstream& ss, const WoundMode&
 	switch (value)
 	{
 	case WoundMode::LINEAR:
-		ss << tr("WRT_LINEAR");
+		ss << tr("WM_LINEAR");
 		break;
 	case WoundMode::VANILLA:
-		ss << tr("WRT_VANILLA");
+		ss << tr("WM_VANILLA");
 		break;
 	case WoundMode::RANDOM:
-		ss << tr("WRT_RANDOM");
+		ss << tr("WM_RANDOM");
 		break;
 	default:
 		ss << tr("STR_UNKNOWN");

--- a/src/Ufopaedia/StatsForNerdsState.cpp
+++ b/src/Ufopaedia/StatsForNerdsState.cpp
@@ -2049,7 +2049,7 @@ void StatsForNerdsState::initItemList()
 		addBoolean(ss, rule->RandomStun, "RandomStun", ruleByResistType->RandomStun);
 
 		addFloatAsPercentage(ss, rule->ToWound, "ToWound", ruleByResistType->ToWound);
-		addBoolean(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
+		addInteger(ss, rule->RandomWound, "RandomWound", ruleByResistType->RandomWound);
 
 		addFloatAsPercentage(ss, rule->ToTime, "ToTime", ruleByResistType->ToTime);
 		addBoolean(ss, rule->RandomTime, "RandomTime", ruleByResistType->RandomTime);

--- a/src/Ufopaedia/StatsForNerdsState.h
+++ b/src/Ufopaedia/StatsForNerdsState.h
@@ -122,6 +122,7 @@ private:
 	void addBattleType(std::ostringstream &ss, const BattleType &value, const std::string &propertyName, const BattleType &defaultvalue = BT_NONE);
 	void addDamageType(std::ostringstream &ss, const ItemDamageType &value, const std::string &propertyName, const ItemDamageType &defaultvalue = DT_NONE);
 	void addDamageRandomType(std::ostringstream &ss, const ItemDamageRandomType &value, const std::string &propertyName, const ItemDamageRandomType &defaultvalue = DRT_DEFAULT);
+	void addWoundMode(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue = WoundMode::VANILLA);
 	void addBattleFuseType(std::ostringstream &ss, const BattleFuseType &value, const std::string &propertyName, const BattleFuseType &defaultvalue = BFT_NONE);
 	void addRuleItemUseCostBasic(std::ostringstream &ss, const RuleItemUseCost &value, const std::string &propertyName, const int &defaultvalue = 0);
 	void addBoolOrInteger(std::ostringstream &ss, const int &value, bool formatAsBoolean);

--- a/src/Ufopaedia/StatsForNerdsState.h
+++ b/src/Ufopaedia/StatsForNerdsState.h
@@ -122,7 +122,7 @@ private:
 	void addBattleType(std::ostringstream &ss, const BattleType &value, const std::string &propertyName, const BattleType &defaultvalue = BT_NONE);
 	void addDamageType(std::ostringstream &ss, const ItemDamageType &value, const std::string &propertyName, const ItemDamageType &defaultvalue = DT_NONE);
 	void addDamageRandomType(std::ostringstream &ss, const ItemDamageRandomType &value, const std::string &propertyName, const ItemDamageRandomType &defaultvalue = DRT_DEFAULT);
-	void addRandomWound(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue = WoundMode::VANILLA);
+	void addRandomWound(std::ostringstream& ss, const ItemWoundRandomType& value, const std::string& propertyName, const ItemWoundRandomType& defaultvalue = ItemWoundRandomType::VANILLA);
 	void addBattleFuseType(std::ostringstream &ss, const BattleFuseType &value, const std::string &propertyName, const BattleFuseType &defaultvalue = BFT_NONE);
 	void addRuleItemUseCostBasic(std::ostringstream &ss, const RuleItemUseCost &value, const std::string &propertyName, const int &defaultvalue = 0);
 	void addBoolOrInteger(std::ostringstream &ss, const int &value, bool formatAsBoolean);

--- a/src/Ufopaedia/StatsForNerdsState.h
+++ b/src/Ufopaedia/StatsForNerdsState.h
@@ -122,7 +122,7 @@ private:
 	void addBattleType(std::ostringstream &ss, const BattleType &value, const std::string &propertyName, const BattleType &defaultvalue = BT_NONE);
 	void addDamageType(std::ostringstream &ss, const ItemDamageType &value, const std::string &propertyName, const ItemDamageType &defaultvalue = DT_NONE);
 	void addDamageRandomType(std::ostringstream &ss, const ItemDamageRandomType &value, const std::string &propertyName, const ItemDamageRandomType &defaultvalue = DRT_DEFAULT);
-	void addWoundMode(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue = WoundMode::VANILLA);
+	void addRandomWound(std::ostringstream& ss, const WoundMode& value, const std::string& propertyName, const WoundMode& defaultvalue = WoundMode::VANILLA);
 	void addBattleFuseType(std::ostringstream &ss, const BattleFuseType &value, const std::string &propertyName, const BattleFuseType &defaultvalue = BFT_NONE);
 	void addRuleItemUseCostBasic(std::ostringstream &ss, const RuleItemUseCost &value, const std::string &propertyName, const int &defaultvalue = 0);
 	void addBoolOrInteger(std::ostringstream &ss, const int &value, bool formatAsBoolean);


### PR DESCRIPTION
### Purpose
- Add a missing wound RNG mode, that all other RNG damage properties have.

### Describe your changes/additions
- Turn wound RNG into a mode selection, instead of a boolean, retaining the behavior of the first two positions (0 and 1), while adding another one, that mimics your average "random" behavior of other damage properties.

### Testing done
- Tested that it works as intended.